### PR TITLE
Loading additional entries

### DIFF
--- a/packages/vite-plugin-shopify/README.md
+++ b/packages/vite-plugin-shopify/README.md
@@ -112,6 +112,19 @@ Then render the `vite-tag` snippet (in your `<head>` element too) to insert tags
 - In development mode, assets are loaded from the Vite development server host.
 - In production mode, assets are loaded from the Shopify CDN using the `asset_url` filter and a relative base path.
 
+Loading `additionalEntrypoints`:
+
+```txt
+# Relative to sourceCodeDir
+{%- render 'vite-tag' with '@/foo.ts' -%}
+{%- render 'vite-tag' with '~/foo.ts' -%}
+
+# Relative to themeRoot
+{%- render 'vite-tag' with '/resources/bar.ts' -%} # leading slash is required
+```
+
+### Import aliases
+
 For convenience, `~/` and `@/` are aliased to your `frontend` folder, which simplifies imports:
 
 ```ts

--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -39,7 +39,7 @@ export default function shopifyHTML (options: ResolvedVitePluginShopifyOptions):
 
       debug({ assetHost })
 
-      const viteTagSnippetContent = viteTagDisclaimer + viteTagEntryPath(config.resolve.alias, options.entrypointsDir) + viteTagSnippetDev(assetHost, options.entrypointsDir, modulesPath)
+      const viteTagSnippetContent = viteTagDisclaimer + viteTagEntryPath(config.resolve.alias, options.entrypointsDir, options.themeRoot) + viteTagSnippetDev(assetHost, options.entrypointsDir, modulesPath)
       const viteClientSnippetContent = viteClientSnippetDev(assetHost)
 
       // Write vite-tag snippet for development server
@@ -116,7 +116,7 @@ export default function shopifyHTML (options: ResolvedVitePluginShopifyOptions):
         }
       })
 
-      const viteTagSnippetContent = viteTagDisclaimer + viteTagEntryPath(config.resolve.alias, options.entrypointsDir) + assetTags.join('\n') + '\n{% endif %}\n'
+      const viteTagSnippetContent = viteTagDisclaimer + viteTagEntryPath(config.resolve.alias, options.entrypointsDir, options.themeRoot) + assetTags.join('\n') + '\n{% endif %}\n'
 
       // Write vite-tag snippet for production build
       fs.writeFileSync(viteTagSnippetPath, viteTagSnippetContent)
@@ -132,7 +132,8 @@ const viteTagDisclaimer = '{% comment %}\n  IMPORTANT: This snippet is automatic
 // Generate liquid variable with resolved path by replacing aliases
 const viteTagEntryPath = (
   resolveAlias: Array<{ find: string | RegExp, replacement: string }>,
-  entrypointsDir: string
+  entrypointsDir: string,
+  themeRoot: string
 ): string => {
   const replacements: Array<[string, string]> = []
 
@@ -142,7 +143,28 @@ const viteTagEntryPath = (
     }
   })
 
-  return `{% assign path = vite-tag | ${replacements.map(([from, to]) => `replace: '${from}/', '${to}/'`).join(' | ')} %}\n`
+  return `{%- liquid
+  assign path_sep = '/'
+  assign path_segments = vite-tag | split: path_sep
+  if path_segments[0] == blank
+    assign is_relative_to_theme_root = true
+  else
+    assign is_relative_to_theme_root = false
+  endif
+  if is_relative_to_theme_root
+    assign new_path = ''
+    for segment in path_segments
+      if forloop.first
+        assign new_path = new_path | append: '${path.relative(entrypointsDir, themeRoot)}'
+      else
+        assign new_path = new_path | append: path_sep | append: segment
+      endif
+    endfor
+    assign path = new_path
+  else
+    assign path = vite-tag | ${replacements.map(([from, to]) => `replace: '${from}/', '${to}/'`).join(' | ')}
+  endif
+-%}\n`
 }
 
 // Generate conditional statement for entry tag

--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -144,23 +144,13 @@ const viteTagEntryPath = (
   })
 
   return `{%- liquid
-  assign path_sep = '/'
-  assign path_segments = vite-tag | split: path_sep
-  if path_segments[0] == blank
+  assign path_prefix = vite-tag | slice: 0
+  assign is_relative_to_theme_root = false
+  if path_prefix == '/'
     assign is_relative_to_theme_root = true
-  else
-    assign is_relative_to_theme_root = false
   endif
   if is_relative_to_theme_root
-    assign new_path = ''
-    for segment in path_segments
-      if forloop.first
-        assign new_path = new_path | append: '${path.relative(entrypointsDir, themeRoot)}'
-      else
-        assign new_path = new_path | append: path_sep | append: segment
-      endif
-    endfor
-    assign path = new_path
+    assign path = vite-tag | prepend: '${path.relative(entrypointsDir, themeRoot)}'
   else
     assign path = vite-tag | ${replacements.map(([from, to]) => `replace: '${from}/', '${to}/'`).join(' | ')}
   endif

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,7 @@ importers:
       tsconfig: workspace:*
       vite: ^3.0.0
       vite-plugin-shopify: workspace:*
+      vite-plugin-shopify-modules: workspace:*
     dependencies:
       lodash-es: 4.17.21
     devDependencies:
@@ -159,6 +160,7 @@ importers:
       tsconfig: link:../../packages/tsconfig
       vite: 3.0.0_sass@1.52.3
       vite-plugin-shopify: link:../../packages/vite-plugin-shopify
+      vite-plugin-shopify-modules: link:../../packages/vite-plugin-shopify-modules
 
 packages:
 
@@ -4244,6 +4246,7 @@ packages:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: false
 
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}

--- a/themes/vite-shopify-example/.shopifyignore
+++ b/themes/vite-shopify-example/.shopifyignore
@@ -1,4 +1,5 @@
 frontend/
+modules/
 package.json
 pnpm-lock.yaml
 .pnpm-debug.log

--- a/themes/vite-shopify-example/frontend/foo.ts
+++ b/themes/vite-shopify-example/frontend/foo.ts
@@ -1,0 +1,1 @@
+import 'vite/modulepreload-polyfill'

--- a/themes/vite-shopify-example/layout/theme.liquid
+++ b/themes/vite-shopify-example/layout/theme.liquid
@@ -14,6 +14,8 @@
   {%- render 'vite-client' -%}
   {%- render 'vite-tag' with 'theme.scss' -%}
   {%- render 'vite-tag' with 'theme.ts' -%}
+  {%- render 'vite-tag' with '@/foo.ts' -%}
+  {%- render 'vite-tag' with '/resources/bar.ts' -%}
 
   {{ content_for_header }}
 </head>

--- a/themes/vite-shopify-example/layout/theme.liquid
+++ b/themes/vite-shopify-example/layout/theme.liquid
@@ -21,6 +21,7 @@
 </head>
 
 <body>
+  {%- section 'cart-drawer' -%}
   {{ content_for_layout }}
 </body>
 </html>

--- a/themes/vite-shopify-example/modules/cart-drawer/cart-drawer.section.liquid
+++ b/themes/vite-shopify-example/modules/cart-drawer/cart-drawer.section.liquid
@@ -1,0 +1,1 @@
+../../sections/cart-drawer.liquid

--- a/themes/vite-shopify-example/modules/cart-drawer/cart-drawer.ts
+++ b/themes/vite-shopify-example/modules/cart-drawer/cart-drawer.ts
@@ -1,0 +1,1 @@
+import 'vite/modulepreload-polyfill'

--- a/themes/vite-shopify-example/package.json
+++ b/themes/vite-shopify-example/package.json
@@ -11,7 +11,8 @@
     "sass": "^1.52.2",
     "tsconfig": "workspace:*",
     "vite": "^3.0.0",
-    "vite-plugin-shopify": "workspace:*"
+    "vite-plugin-shopify": "workspace:*",
+    "vite-plugin-shopify-modules": "workspace:*"
   },
   "dependencies": {
     "lodash-es": "^4.17.21"

--- a/themes/vite-shopify-example/resources/bar.ts
+++ b/themes/vite-shopify-example/resources/bar.ts
@@ -1,0 +1,1 @@
+import 'vite/modulepreload-polyfill'

--- a/themes/vite-shopify-example/sections/cart-drawer.liquid
+++ b/themes/vite-shopify-example/sections/cart-drawer.liquid
@@ -1,0 +1,1 @@
+{%- render 'vite-tag' with '@modules/cart-drawer/cart-drawer.ts' -%}

--- a/themes/vite-shopify-example/vite.config.ts
+++ b/themes/vite-shopify-example/vite.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from 'vite'
 import shopify from 'vite-plugin-shopify'
+import shopifyModules from 'vite-plugin-shopify-modules'
 
 export default defineConfig({
   plugins: [
     shopify({
       additionalEntrypoints: [
         'frontend/foo.ts', // relative to sourceCodeDir
-        'resources/bar.ts' // relative to themeRoot
+        'resources/bar.ts', // relative to themeRoot
+        'modules/**/*.{ts,js}'
       ]
-    })
+    }),
+    shopifyModules()
   ],
   build: {
     emptyOutDir: true

--- a/themes/vite-shopify-example/vite.config.ts
+++ b/themes/vite-shopify-example/vite.config.ts
@@ -3,7 +3,12 @@ import shopify from 'vite-plugin-shopify'
 
 export default defineConfig({
   plugins: [
-    shopify()
+    shopify({
+      additionalEntrypoints: [
+        'frontend/foo.ts', // relative to sourceCodeDir
+        'resources/bar.ts' // relative to themeRoot
+      ]
+    })
   ],
   build: {
     emptyOutDir: true


### PR DESCRIPTION
Fixes #10 

* Added logic load entries relative to the root of the theme with the `/` symbol
* Updated example to verify functionality
* Added documentation for loading `additionalEntrypoints`

Demo 🚀 
* [View theme](https://base-dev.myshopify.com/?preview_theme_id=121466355789)
* [Theme editor](https://base-dev.myshopify.com/admin/themes/121466355789?key=snippets%2Fvite-tag.liquid)