### PR TITLE
Update product-grid-toggle with deferred rendering

### DIFF
--- a/themes/seed-theme/frontend/scripts/dynamic-section-element.js
+++ b/themes/seed-theme/frontend/scripts/dynamic-section-element.js
@@ -44,7 +44,11 @@ class DynamicSectionElement extends HTMLElement {
     }
 
     // Find all descendant elements with data-slot attribute and update each with new contents
-    const oldSlots = this.querySelectorAll('[data-slot]')
+    let oldSlots = this.querySelectorAll('[data-slot]')
+
+    if (options.onlySlots?.length) {
+      oldSlots = [...oldSlots].filter((slotEl) => options.onlySlots.includes(slotEl.dataset.slot))
+    }
 
     oldSlots.forEach((oldSlotEl) => {
       const slotName = oldSlotEl.dataset.slot

--- a/themes/seed-theme/modules/product-grid-toggle/product-grid-toggle.js
+++ b/themes/seed-theme/modules/product-grid-toggle/product-grid-toggle.js
@@ -1,41 +1,62 @@
-class ProductGridToggle extends HTMLElement {
+import DynamicSectionElement from '@/scripts/dynamic-section-element'
+
+/**
+ * ProductGridToggle wraps multiple product grids and enables toggling between them
+ */
+class ProductGridToggle extends DynamicSectionElement {
   constructor () {
     super()
 
-    const toggleProductGridVisibility = (value) => {
-      const selectedIndex = parseInt(value) - 1
+    // Save reference to product grid container elements
+    this.productGrids = this.querySelectorAll('[data-slot^="product-grid-toggle"]')
 
-      this.siblingProductGridSections.forEach((siblingSection, index) => {
-        if (index === selectedIndex) {
-          siblingSection.classList.remove('hidden')
-        } else {
-          siblingSection.classList.add('hidden')
-        }
-      })
-    }
-
-    // Toggle visibility based on radio button change event
-    this.addEventListener('change', (event) => {
-      toggleProductGridVisibility(event.target.value)
-    })
-
-    // Set initial state with first product grid visible
-    toggleProductGridVisibility('1')
-
-    this.parentElement.addEventListener('shopify:block:select', (event) => {
-      const index = [...event.target.parentElement.children].indexOf(event.target)
-      console.log({ event, index })
-      toggleProductGridVisibility(`${index + 1}`)
-      const checkbox = event.target.querySelector('input')
-
-      if (!checkbox.checked) {
-        checkbox.checked = true
+    // Toggle active grid based on button click
+    this.addEventListener('click', (event) => {
+      if (event.target.tagName === 'BUTTON' && event.target.dataset.toggle) {
+        this.toggleProductGrid(parseInt(event.target.dataset.toggle, 10))
       }
     })
+
+    // Toggle active grid based on theme customizer position
+    this.parentElement.addEventListener('shopify:block:select', (event) => {
+      const selectedIndex = [...event.target.parentElement.children].indexOf(event.target)
+      this.toggleProductGrid(selectedIndex)
+    })
+
+    // Load additional tabs if deferred from initial liquid render
+    if (this.hasAttribute('defer-additional-tabs')) {
+      this.renderAdditionalTabs()
+    }
   }
 
-  get siblingProductGridSections () {
-    return this.parentElement.querySelectorAll('[data-module="product-grid"]')
+  toggleProductGrid (selectedIndex = 0) {
+    this.productGrids.forEach((productGrid, index) => {
+      if (index === selectedIndex) {
+        productGrid.classList.remove('hidden')
+        productGrid.querySelector('slider-base')?.embla?.reInit()
+      } else {
+        productGrid.classList.add('hidden')
+      }
+    })
+    this.querySelector('button[data-toggle].active').classList.remove('active')
+    this.querySelector(`button[data-toggle="${selectedIndex}"]`).classList.add('active')
+  }
+
+  renderAdditionalTabs () {
+    const params = new URLSearchParams({
+      view: 'ajax',
+      section_id: this.parentElement.id.slice('shopify-section-'.length)
+    })
+    fetch(`${window.location.pathname}?${params}`)
+      .then((response) => response.text())
+      .then((responseText) => {
+        const newSectionEl = new DOMParser()
+          .parseFromString(responseText, 'text/html')
+
+        this.replaceContent(newSectionEl, {
+          onlySlots: ['product-grid-toggle-2', 'product-grid-toggle-3']
+        })
+      })
   }
 }
 

--- a/themes/seed-theme/sections/product-grid-toggle.liquid
+++ b/themes/seed-theme/sections/product-grid-toggle.liquid
@@ -1,33 +1,54 @@
 {% liquid
-  if section.blocks.size == 1
-    assign grid_cols_class = 'grid-cols-1'
-  elsif section.blocks.size == 2
-    assign grid_cols_class = 'grid-cols-2'
-  else
-    assign grid_cols_class = 'grid-cols-3'
+  if template.name == 'index'
+    assign defer_additional_tabs = true
   endif
-
-  assign toggle_wrapper_class = "inline-grid grid-cols-2 gap-x-6 " | append: grid_cols_class
 %}
-
-<product-grid-toggle data-module="product-grid-toggle" class="block text-center">
-  <div>
+<product-grid-toggle data-module="product-grid-toggle" {% if defer_additional_tabs %}defer-additional-tabs{% endif %}>
+  <div class="block text-center">
     {% render 'rich-text', heading: section.settings.heading %}
-  </div>
-  <div class="{{ toggle_wrapper_class }}">
-    {% for block in section.blocks %}
-      <label {{ block.shopify_attributes }}>
-        <input class="peer" type="radio" name="{{- section.id -}}" value="{{ forloop.index | add: 1 }}" {% if forloop.first %}checked{% endif %}>
-        <span class="peer-checked:font-bold">
+    <div class="inline-flex overflow-auto max-w-full">
+      {% for block in section.blocks %}
+        <button
+          {{ block.shopify_attributes }}
+          data-toggle="{{ forloop.index0 }}"
+          class="h2 m-4 text-gray-400 whitespace-nowrap [&.active]:text-black [&.active]:underline{% if forloop.first %} active{% endif %}"
+        >
           {{- block.settings.toggle_text -}}
-        </span>
-      </label>
-    {% endfor %}
+        </button>
+      {% endfor %}
+    </div>
   </div>
+  {% for block in section.blocks %}
+    {% liquid
+      assign render_block = true
+
+      if defer_additional_tabs
+        if template.suffix != 'ajax' and forloop.index0 != 0
+          assign render_block = false
+        elsif template.suffix == 'ajax' and forloop.index0 == 0
+          assign render_block = false
+        endif
+      endif
+    %}
+    <div data-slot="product-grid-toggle-{{ forloop.index }}" class="{% if forloop.index0 > 0 %}hidden{% endif %}">
+      {% if render_block == true %}
+        {% liquid
+          assign lazy_load_images = true
+          if template.name contains 'index' and forloop.index0 == 0
+            assign lazy_load_images = false
+          endif
+
+          if block.type == 'curated-product-grid'
+            assign grid_products = block.settings.products
+          else
+            assign grid_products = block.settings.collection.products
+          endif
+        %}
+        {% render 'product-grid', products: grid_products, lazy_load_images: lazy_load_images, enable_slider: true %}
+      {% endif %}
+    </div>
+  {% endfor %}
 </product-grid-toggle>
-{% for block in section.blocks %}
-  {% render 'product-grid', products: block.settings.products %}
-{% endfor %}
 {% render 'vite-tag' with '@modules/product-grid-toggle' %}
 {% schema %}
 {
@@ -41,8 +62,8 @@
   ],
   "blocks": [
     {
-      "type": "product-grid",
-      "name": "Product Grid",
+      "type": "curated-product-grid",
+      "name": "Curated Product Grid",
       "settings": [
         {
           "type": "text",
@@ -54,6 +75,23 @@
           "id": "products",
           "label": "Products",
           "info": "Select one or more products to feature in this section."
+        }
+      ]
+    },
+    {
+      "type": "collection-product-grid",
+      "name": "Collection Product Grid",
+      "settings": [
+        {
+          "type": "text",
+          "id": "toggle_text",
+          "label": "Toggle Text"
+        },
+        {
+          "type": "collection",
+          "id": "collection",
+          "label": "Collection",
+          "info": "Select a collection from which to feature products in this section."
         }
       ]
     }

--- a/themes/seed-theme/templates/index.ajax.liquid
+++ b/themes/seed-theme/templates/index.ajax.liquid
@@ -1,0 +1,5 @@
+{% comment %}
+  This file is intentionally left blank!
+
+  It exists solely to create an alternate "ajax" view for the index page, which can be used along with the Section Rendering API to defer rendering of non-critical content so that it can be added in later using an AJAX request without incurring additional cost to the initial server response time. An example of this is shown in the "product-grid-toggle" module.
+{% endcomment %}

--- a/themes/seed-theme/templates/index.json
+++ b/themes/seed-theme/templates/index.json
@@ -50,47 +50,36 @@
     "home_product_grid_toggle": {
       "type": "product-grid-toggle",
       "blocks": {
-        "36177fb6-50e7-47b6-b384-14f74bbc9526": {
-          "type": "product-grid",
+        "b83b1750-6549-4aab-a81a-c2c5f41bfb9b": {
+          "type": "collection-product-grid",
           "settings": {
-            "toggle_text": "Outfit your kitchen",
-            "products": [
-              "black-sunglasses",
-              "blue-denim-jacket",
-              "blue-twill-shirt",
-              "black-straight-leg-jeans"
-            ]
+            "toggle_text": "Outerwear",
+            "collection": "outerwear"
           }
         },
-        "87b985f7-229f-45f8-bd5d-f936a601e5f7": {
-          "type": "product-grid",
+        "269e873b-8ef3-462e-aaa4-736ef3342d59": {
+          "type": "collection-product-grid",
           "settings": {
-            "toggle_text": "Get the perfect yard",
+            "toggle_text": "Denim",
+            "collection": "denim"
+          }
+        },
+        "9fdaf22b-f1be-4b1e-829a-20814bc16d13": {
+          "type": "curated-product-grid",
+          "settings": {
+            "toggle_text": "Random Stuff",
             "products": [
               "2020-spirit-horse-vineyards-estate-cavallino-pinot-grigio",
-              "2015-mathew-bruno-napa-valley-cabernet-sauvignon",
-              "2018-priest-ranch-snake-oil-1",
-              "2015-somerston-cabernet-sauvignon-block-96"
-            ]
-          }
-        },
-        "a1f72149-6bac-4499-b7ea-e181b65e56f9": {
-          "type": "product-grid",
-          "settings": {
-            "toggle_text": "The cleanest clean",
-            "products": [
-              "velvet-blazer",
-              "teal-flared-leggings",
-              "tan-winter-jacket",
-              "tomato"
+              "brera-frame-only",
+              "velvet-blazer"
             ]
           }
         }
       },
       "block_order": [
-        "36177fb6-50e7-47b6-b384-14f74bbc9526",
-        "87b985f7-229f-45f8-bd5d-f936a601e5f7",
-        "a1f72149-6bac-4499-b7ea-e181b65e56f9"
+        "b83b1750-6549-4aab-a81a-c2c5f41bfb9b",
+        "269e873b-8ef3-462e-aaa4-736ef3342d59",
+        "9fdaf22b-f1be-4b1e-829a-20814bc16d13"
       ],
       "settings": {
         "heading": "Spend more time enjoying your space, inside & out."


### PR DESCRIPTION
This branch implements a proof-of-concept for deferring the liquid rendering logic for additional product grids which are hidden on the initial page load in the `product-grid-toggle` section.

- `templates/index.ajax.liquid` was created so we can request AJAX-specific variations of modules on the index page using the Section Rendering API.
- `sections/product-grid-toggle.liquid` was updated so that it only renders the first product grid when serving the index page. When requested with the section rendering API using the `view=ajax` parameter, the AJAX-specific logic is activated to only render the additional tabs. (_Note: This branch also happens to include some prior changes I made to the `product-grid-toggle` section blocks to allow for showing collections as well as curated product lists. These are not relevant to the AJAX functionality._)
- `modules/product-grid-toggle.js` was updated to request the AJAX variation of the section and inject the deferred content into the module using `DynamicSectionElement`.
- `frontend/scripts/dynamic-section-element.js` was updated to add support for an `onlySlots` option, to control which slots in the re-rendered module will be replaced. This was needed so that `product-grid-toggle` could replace the content for the additional deferred tabs without affecting the initial tab.