### PR TITLE
Remove querystring from asset URLs

### DIFF
--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -151,15 +151,15 @@ const viteEntryTag = (entryPaths: string[], tag: string, isFirstEntry = false): 
 
 // Generate a preload link tag for a script or style asset
 const preloadScriptTag = (fileName: string): string =>
-  `<link rel="modulepreload" href="{{ '${fileName}' | asset_url }}" crossorigin="anonymous">`
+  `<link rel="modulepreload" href="{{ '${fileName}' | asset_url | split: '?' | first }}" crossorigin="anonymous">`
 
 // Generate a production script tag for a script asset
 const scriptTag = (fileName: string): string =>
-  `<script src="{{ '${fileName}' | asset_url }}" type="module" crossorigin="anonymous"></script>`
+  `<script src="{{ '${fileName}' | asset_url | split: '?' | first }}" type="module" crossorigin="anonymous"></script>`
 
 // Generate a production stylesheet link tag for a style asset
 const stylesheetTag = (fileName: string): string =>
-  `{{ '${fileName}' | asset_url | stylesheet_tag: preload: preload_stylesheet }}`
+  `{{ '${fileName}' | asset_url | split: '?' | first | stylesheet_tag: preload: preload_stylesheet }}`
 
 // Generate vite-tag snippet for development
 const viteTagSnippetDev = (assetHost = 'http://localhost:5173', entrypointsDir = 'frontend/entrypoints', modulesPath = ''): string =>


### PR DESCRIPTION
* The `v` param that `asset_url` adds to the assets is not needed for assets generated by vite
  * The `[hash]` on the file names ensures we always get the latest version for a given asset


This PR removes the querystring from asset URLs so that they don't download twice

<img width="695" alt="Screen Shot 2022-10-31 at 8 43 13 AM" src="https://user-images.githubusercontent.com/5134470/199050434-dcc10418-af74-4aa1-b387-7cdab6dedd3b.png">
