### PR TITLE
If a module script exists, resolve it

### DIFF
--- a/packages/vite-plugin-shopify-modules/src/index.ts
+++ b/packages/vite-plugin-shopify-modules/src/index.ts
@@ -40,19 +40,28 @@ export default function shopifyModules (options: VitePluginShopifyModulesOptions
     resolveId: async (id) => {
       // Check if path is within modules directory
       if (!path.relative(path.resolve(resolvedOptions.modulesDir), id).includes('..')) {
-        const fileStat = await fs.stat(id)
+        try {
+          const fileStat = await fs.stat(id)
 
-        // Check if path refers to folder instead of file
-        if (fileStat.isDirectory()) {
-          // Check if module script file exists matching folder name
-          const results = await glob(`${id}/${path.basename(id)}.{js,jsx,ts,tsx}`, { onlyFiles: true })
+          // Check if path refers to folder instead of file
+          if (fileStat.isDirectory()) {
+            // Check if module script file exists matching folder name
+            const results = await glob(`${id}/${path.basename(id)}.{js,jsx,ts,tsx}`, { onlyFiles: true })
 
-          // Resolve to actual file path instead of module shorthand
-          if (results.length > 0) {
-            return results[0]
+            // Resolve to actual file path instead of module shorthand
+            if (results.length > 0) {
+              return results[0]
+            }
+
+            // No file matches the folder name
+            return null
           }
+        } catch (e) {
+          // The dirctory does not exist
+          return null
         }
       }
+      return null
     },
     buildStart: () => {
       // Link modules on build start


### PR DESCRIPTION
Fixes #39 

* This PR validates the presence of a script module
* If it exists, it resolves it, otherwise, let Vite handle the error by returning null